### PR TITLE
Fix: Correct Colab link for Resting_membrane_potential.ipynb

### DIFF
--- a/Resting_membrane_potential.ipynb
+++ b/Resting_membrane_potential.ipynb
@@ -11,7 +11,7 @@
     "tags": []
    },
    "source": [
-    "[![Open In Colab](./colab-badge.png)](https://colab.research.google.com/github/subhacom/moose-notebooks/blob/main/Multi-compartmental_neuron_model.ipynb) [![Binder](./binder_logo.png)](https://mybinder.org/v2/gh/subhacom/moose-notebooks/HEAD)"
+    "[![Open In Colab](./colab-badge.png)](https://colab.research.google.com/github/subhacom/moose-notebooks/blob/main/Resting_membrane_potential.ipynb) [![Binder](./binder_logo.png)](https://mybinder.org/v2/gh/subhacom/moose-notebooks/HEAD)"
    ]
   },
   {


### PR DESCRIPTION
- Updated the Colab link in the README to point to the correct Resting_membrane_potential.ipynb notebook.